### PR TITLE
Added callback to fs.mkdir()

### DIFF
--- a/lib/utils/file.js
+++ b/lib/utils/file.js
@@ -48,7 +48,7 @@ Fi.prototype._mkdir = async function(pos, dirArray) {
 
   if (!exist) {
     try {
-      fs.mkdir(currentDir);
+      fs.mkdir(currentDir, err => { if (err) console.log(err) });
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
fs.mkdir() expects a file and a call back to properly function.